### PR TITLE
Update repo name ("splitlab_stacksplit" to "splitlab-stacksplit") in links

### DIFF
--- a/02_stacksplit/README.md
+++ b/02_stacksplit/README.md
@@ -6,7 +6,7 @@
 > Updated versions based on [StackSplit v3.0](https://github.com/michaelgrund/stacksplit/releases/tag/v3.0).
 >
 > No compatibility of StackSplit with MATLAB R2025a yet
-> (please see [issue 12](https://github.com/yvonnefroehlich/splitlab_stacksplit/issues/12) for details).
+> (please see [issue 12](https://github.com/yvonnefroehlich/splitlab-stacksplit/issues/12) for details).
 
 
 StackSplit ([**_Grund 2017_**](https://doi.org/10.1016/j.cageo.2017.04.015)) is a plugin for the MATLAB toolbox
@@ -14,7 +14,7 @@ SplitLab ([**_Wüstefeld et al. 2008_**](https://www.sciencedirect.com/science/a
 which allows applying multi-event techniques for shear wave splitting (SWS) measurements directly within the
 main program.
 
-For details regarding installation and usage, see the [UserGuide](https://github.com/yvonnefroehlich/splitlab_stacksplit/blob/main/02_stacksplit/StackSplit/Doc/StackSplit_userguide.md).
+For details regarding installation and usage, see the [UserGuide](https://github.com/yvonnefroehlich/splitlab-stacksplit/blob/main/02_stacksplit/StackSplit/Doc/StackSplit_userguide.md).
 
 
 ## Citation
@@ -58,13 +58,13 @@ be processed:
 
 | StackSplit | Date | Zenodo DOI | SplitLab | MATLAB |
 | --- | --- | --- | --- | --- |
-| [dev YF](https://github.com/yvonnefroehlich/splitlab_stacksplit) | | | [1.2.1](https://robporritt.wordpress.com/software/), 1.0.5 (not tested) | >= [2024b](https://mathworks.com/help/releases/R2024b/index.html) (< 2024b might work, but not tested yet) |
+| [dev YF](https://github.com/yvonnefroehlich/splitlab-stacksplit) | | | [1.2.1](https://robporritt.wordpress.com/software/), 1.0.5 (not tested) | >= [2024b](https://mathworks.com/help/releases/R2024b/index.html) (< 2024b might work, but not tested yet) |
 | [dev MG](https://github.com/michaelgrund/stacksplit) | | | [1.2.1](https://robporritt.wordpress.com/software/), 1.0.5 (not tested) | >= [2020a](https://mathworks.com/help/releases/R2020a/index.html) (< 2020a might work, but not tested yet) |
 | [v3.0](https://github.com/michaelgrund/stacksplit/releases/tag/v3.0) | 2021/12/23 | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5802051.svg)](https://doi.org/10.5281/zenodo.5802051) | [1.2.1](https://robporritt.wordpress.com/software/), 1.0.5 (not tested) | >= [2020a](https://mathworks.com/help/releases/R2020a/index.html) (< 2020a might work, but not tested yet) |
 | [v2.0](https://github.com/michaelgrund/stacksplit/releases/tag/v2.0) | 2019/06/28 | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7118716.svg)](https://doi.org/10.5281/zenodo.7118716) | [1.2.1](https://robporritt.wordpress.com/software/), 1.0.5 | >= [2014b](https://mathworks.com/company/newsroom/mathworks-introduces-new-features-in-matlab-and-simulink.html) (tested up to and including [2018b](https://mathworks.com/help/releases/R2018b/index.html)) |
 | [v1.0](https://github.com/michaelgrund/stacksplit/releases/tag/v1.0) | 2017/04/04 | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.464385.svg)](https://doi.org/10.5281/zenodo.464385) | [1.2.1](https://robporritt.wordpress.com/software/), 1.0.5 | <= [2014a](https://mathworks.com/company/newsroom/mathworks-announces-release-2014a-of-the-matlab-and-simulink-product-families.html) |
 
-For details regarding the different StackSplit versions, see the [Changelog](https://github.com/yvonnefroehlich/splitlab_stacksplit/blob/main/02_stacksplit/changelog.md).
+For details regarding the different StackSplit versions, see the [Changelog](https://github.com/yvonnefroehlich/splitlab-stacksplit/blob/main/02_stacksplit/changelog.md).
 
 
 ## References

--- a/02_stacksplit/StackSplit/Doc/StackSplit_userguide.md
+++ b/02_stacksplit/StackSplit/Doc/StackSplit_userguide.md
@@ -45,7 +45,7 @@ version of Rob Porritt. However, StackSplit was designed to work with both versi
 Toolbox) and the installer checks which of both is stored on your system.
 
 For details regarding the different StackSplit versions see the
-[Changelog](https://github.com/yvonnefroehlich/splitlab_stacksplit/blob/main/02_stacksplit/changelog.md).
+[Changelog](https://github.com/yvonnefroehlich/splitlab-stacksplit/blob/main/02_stacksplit/changelog.md).
 
 For further information on SplitLab see the corresponding User Guide that is included in the download package.
 
@@ -64,15 +64,15 @@ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License3 for more d
 ## Bugs and errors
 
 If any problems occur while installing/running StackSplit (especially due to MATLAB version issues)
-or you found a potential bug, please feel free to open a new [issue](https://github.com/yvonnefroehlich/splitlab_stacksplit/issues)
-or [pull request](https://github.com/yvonnefroehlich/splitlab_stacksplit/pulls) here on GitHub. Please indicate the corresponding
+or you found a potential bug, please feel free to open a new [issue](https://github.com/yvonnefroehlich/splitlab-stacksplit/issues)
+or [pull request](https://github.com/yvonnefroehlich/splitlab-stacksplit/pulls) here on GitHub. Please indicate the corresponding
 function that generates the error and/or copy/paste the whole error message output of MATLAB. If StackSplit does not
 fulfill your expectations, don't hesitate to provide comments and suggestions for improvements etc.
 
 
 ## Miscellaneous
 
-For updates of the StackSplit package, please have a look on the [GitHub repo](https://github.com/yvonnefroehlich/splitlab_stacksplit).
+For updates of the StackSplit package, please have a look on the [GitHub repo](https://github.com/yvonnefroehlich/splitlab-stacksplit).
 
 If you make use of StackSplit please acknowledge the following contributing papers:
 

--- a/02_stacksplit/StackSplit/SS_basic_settings.m
+++ b/02_stacksplit/StackSplit/SS_basic_settings.m
@@ -15,7 +15,7 @@ function h = SS_basic_settings(h, merged_str, find_res)
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_calc_RH.m
+++ b/02_stacksplit/StackSplit/SS_calc_RH.m
@@ -19,7 +19,7 @@ function [wf, countN] = SS_calc_RH(SNR, bazi_single, bazi_all, h)
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_calc_SIMW.m
+++ b/02_stacksplit/StackSplit/SS_calc_SIMW.m
@@ -17,7 +17,7 @@ function SS_calc_SIMW(h)
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_check_input.m
+++ b/02_stacksplit/StackSplit/SS_check_input.m
@@ -17,7 +17,7 @@ function [f, sampling, find_res] = SS_check_input(find_res)
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_check_matlab_version.m
+++ b/02_stacksplit/StackSplit/SS_check_matlab_version.m
@@ -33,7 +33,7 @@ function vers_out = SS_check_matlab_version()
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_disp_Esurf_single.m
+++ b/02_stacksplit/StackSplit/SS_disp_Esurf_single.m
@@ -15,7 +15,7 @@ function h = SS_disp_Esurf_single(h, index)
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_gen_legends.m
+++ b/02_stacksplit/StackSplit/SS_gen_legends.m
@@ -16,7 +16,7 @@ function h = SS_gen_legends(h)
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_gen_stackresplot.m
+++ b/02_stacksplit/StackSplit/SS_gen_stackresplot.m
@@ -18,7 +18,7 @@ function SS_gen_stackresplot( ...
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_gen_worldmap.m
+++ b/02_stacksplit/StackSplit/SS_gen_worldmap.m
@@ -16,7 +16,7 @@ function h = SS_gen_worldmap(h)
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_geterrorbars_stack_Esurf.m
+++ b/02_stacksplit/StackSplit/SS_geterrorbars_stack_Esurf.m
@@ -20,7 +20,7 @@ function [errbar_phi, errbar_t, Ecrit] = SS_geterrorbars_stack_Esurf( ...
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_layout.m
+++ b/02_stacksplit/StackSplit/SS_layout.m
@@ -21,7 +21,7 @@ function h = SS_layout( ...
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_prep_SIMW.m
+++ b/02_stacksplit/StackSplit/SS_prep_SIMW.m
@@ -15,7 +15,7 @@ function h = SS_prep_SIMW(h)
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_read_SLresults.m
+++ b/02_stacksplit/StackSplit/SS_read_SLresults.m
@@ -17,7 +17,7 @@ function [merged_str, find_res] = SS_read_SLresults( ...
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_saveresults.m
+++ b/02_stacksplit/StackSplit/SS_saveresults.m
@@ -19,7 +19,7 @@ function h = SS_saveresults(h)
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_splitdiagnosticLayout.m
+++ b/02_stacksplit/StackSplit/SS_splitdiagnosticLayout.m
@@ -16,7 +16,7 @@ function [axH, axRC, axSC, axSeis, axwm] = SS_splitdiagnosticLayout(Synfig)
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_splitdiagnosticSetHeader.m
+++ b/02_stacksplit/StackSplit/SS_splitdiagnosticSetHeader.m
@@ -20,7 +20,7 @@ function SS_splitdiagnosticSetHeader( ...
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_splitdiagnosticplot.m
+++ b/02_stacksplit/StackSplit/SS_splitdiagnosticplot.m
@@ -21,7 +21,7 @@ function SS_splitdiagnosticplot( ...
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_stack_Esurf.m
+++ b/02_stacksplit/StackSplit/SS_stack_Esurf.m
@@ -25,7 +25,7 @@ function h = SS_stack_Esurf(h)
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/SS_stacksplit_start.m
+++ b/02_stacksplit/StackSplit/SS_stacksplit_start.m
@@ -92,7 +92,7 @@ function SS_stacksplit_start
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/install_StackSplit.m
+++ b/02_stacksplit/StackSplit/install_StackSplit.m
@@ -69,7 +69,7 @@ function install_StackSplit()
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/StackSplit/uninstall_StackSplit.m
+++ b/02_stacksplit/StackSplit/uninstall_StackSplit.m
@@ -25,7 +25,7 @@ function uninstall_StackSplit()
 % LICENSE
 %
 % Copyright (C) 2025  Michael Grund & Yvonne Fröhlich (up on v4.0)
-% GitHub: https://github.com/yvonnefroehlich/splitlab_stacksplit -> folder 02_stacksplit
+% GitHub: https://github.com/yvonnefroehlich/splitlab-stacksplit -> folder 02_stacksplit
 % Copyright (C) 2021  Michael Grund & Yvonne Fröhlich (v3.0)
 % Copyright (C) 2016  Michael Grund, Karlsruhe Institute of Technology (KIT) (v1.0-v2.0)
 % GitHub: https://github.com/michaelgrund

--- a/02_stacksplit/changelog.md
+++ b/02_stacksplit/changelog.md
@@ -10,7 +10,7 @@
 - Fix vline in exported STACK diagplot ([#5](https://github.com/michaelgrund/stacksplit/pull/5)* by YF)
 - Improve code and docs ([#24](https://github.com/michaelgrund/stacksplit/pull/24)* by YF)
 - Update docs and comments ([#11](https://github.com/michaelgrund/stacksplit/pull/11)* by YF)
-- Use tables in README ([367934a](https://github.com/yvonnefroehlich/splitlab_stacksplit/commit/367934a76a0780be8e65c0d6762a30cb6ec75de4) by YF)
+- Use tables in README ([367934a](https://github.com/yvonnefroehlich/splitlab-stacksplit/commit/367934a76a0780be8e65c0d6762a30cb6ec75de4) by YF)
 - Improve README ([#17](https://github.com/michaelgrund/stacksplit/pull/17)* by YF and [#28](https://github.com/michaelgrund/stacksplit/pull/28)* by MG)
 - Fix typos in "StackSplit - UserGuide" ([#10](https://github.com/michaelgrund/stacksplit/pull/10)* by YF)
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 ## Updated versions of
 
-- [01_splitlab](https://github.com/yvonnefroehlich/splitlab_stacksplit/tree/main/01_splitlab):
+- [01_splitlab](https://github.com/yvonnefroehlich/splitlab-stacksplit/tree/main/01_splitlab):
   **SplitLab** ([**_Wüstefeld et al. 2008_**](https://doi.org/10.1016/j.cageo.2007.08.002)) based on [SplitLab 1.2.1](https://robporritt.wordpress.com/software/)
-- [02_stacksplit](https://github.com/yvonnefroehlich/splitlab_stacksplit/tree/main/02_stacksplit):
+- [02_stacksplit](https://github.com/yvonnefroehlich/splitlab-stacksplit/tree/main/02_stacksplit):
   **StackSplit** ([**_Grund 2017_**](https://doi.org/10.1016/j.cageo.2017.04.015)) based on [StackSplit v3.0](https://github.com/michaelgrund/stacksplit/releases/tag/v3.0)
 
 


### PR DESCRIPTION
Repo renamed from `splitlab_stacksplit` to `splitlab-stacksplit` (underscore to hypen).

**Previews**
- main README: https://github.com/yvonnefroehlich/splitlab-stacksplit/blob/update-links-renamerepo/README.md
- StackSplit README: https://github.com/yvonnefroehlich/splitlab-stacksplit/blob/update-links-renamerepo/02_stacksplit/README.md
- StackSplit changelog: https://github.com/yvonnefroehlich/splitlab-stacksplit/blob/update-links-renamerepo/02_stacksplit/changelog.md