### PR TITLE
Update link to SplitLab website (http -> https)

### DIFF
--- a/01_splitlab/README.md
+++ b/01_splitlab/README.md
@@ -12,18 +12,18 @@
 
 | Version | Description | Author |
 | --- | --- | --- |
-| [SplitLab 1.0.5](http://splitting.gm.univ-montp2.fr/) | Original SplitLab version | Andreas Wüstefeld |
-| [SplitLab 1.2.1](https://robporritt.wordpress.com/software/) | Update of SplitLab 1.0.5 | Rob Porritt |
+| [SplitLab 1.0.5](https://splitting.gm.univ-montp2.fr) | Original SplitLab version | Andreas Wüstefeld |
+| [SplitLab 1.2.1](https://robporritt.wordpress.com/software) | Update of SplitLab 1.0.5 | Rob Porritt |
 | [SplitLab 1.3.0](https://github.com/nmcreasy/SplitLab1.3.0) | Update of SplitLab 1.2.1 | Neala Creasy |
 | [SplitLab 1.9.0](https://github.com/IPGP/splitlab) | Most recent SplitLab version | IPGP |
 
 
 ## References
 
-- [**_Wüstefeld, A. (2007)_**](http://splitting.gm.univ-montp2.fr/).
+- [**_Wüstefeld, A. (2007)_**](https://splitting.gm.univ-montp2.fr).
   Methods and applications of shear wave splitting: The East European Craton.
   *Ph.D. thesis*, Univ. de Montpellier, France.
-  http://splitting.gm.univ-montp2.fr/.
+  https://splitting.gm.univ-montp2.fr.
 - [**_Wüstefeld, A., Bokelmann, G., Zaroli, C., Barruol, G. (2008)_**](https://doi.org/10.1016/j.cageo.2007.08.002).
   SplitLab: A shear-wave splitting environment in Matlab.
   *Computers & Geosciences*, 34, 515–528.

--- a/02_stacksplit/README.md
+++ b/02_stacksplit/README.md
@@ -48,7 +48,7 @@ be processed:
 | --- | --- | --- | --- |
 | **WS** | Stacking of error surfaces | Normalization on the minimum or maximum (depending on input) of each single surface | [**_Wolfe & Silver (1998)_**](https://doi.org/10.1029/97JB02023) |
 | **RH** | Modified WS method | Weighting on the SNR of each measurement; normalization regarding the available backazimuth directions | [**_Restivo & Helffrich (1999)_**](https://doi.org/10.1046/j.1365-246x.1999.00845.x) |
-| **no weight** | Stacking of error surfaces | No weighting | [**_Wüstefeld (2007)_**](http://splitting.gm.univ-montp2.fr/) |
+| **no weight** | Stacking of error surfaces | No weighting | [**_Wüstefeld (2007)_**](https://splitting.gm.univ-montp2.fr/) |
 | **SIMW** | Simultaneous inversion of multiple waveforms | Waveform concentration and joint inversion in time domain | [**_Roy et al. (2017)_**](https://doi.org/10.1093/gji/ggw470) |
 
 ![fig4github](https://user-images.githubusercontent.com/23025878/56716351-6d3d2a80-673a-11e9-8b34-2191c119d780.png)
@@ -81,10 +81,10 @@ For details regarding the different StackSplit versions, see the [Changelog](htt
   Seismic anisotropy of oceanic upper mantle: Shear wave splitting methodologies and observations.
   *Journal of Geophysical Research*, 103(B1), 749-771,
   https://doi.org/10.1029/97JB02023.
-- [**_Wüstefeld, A. (2007)_**](http://splitting.gm.univ-montp2.fr/).
+- [**_Wüstefeld, A. (2007)_**](https://splitting.gm.univ-montp2.fr/).
   Methods and applications of shear wave splitting: The East European Craton.
   *Ph.D. thesis*, Univ. de Montpellier, France.
-  http://splitting.gm.univ-montp2.fr/.
+  https://splitting.gm.univ-montp2.fr/.
 - [**_Wüstefeld, A., Bokelmann, G., Zaroli, C., Barruol, G. (2008)_**](https://doi.org/10.1016/j.cageo.2007.08.002).
   SplitLab: A shear-wave splitting environment in Matlab.
   *Computers & Geosciences*, 34, 515–528,

--- a/02_stacksplit/StackSplit/Doc/StackSplit_userguide.md
+++ b/02_stacksplit/StackSplit/Doc/StackSplit_userguide.md
@@ -37,7 +37,7 @@
 
 ## Requirements
 
-StackSplit should run on every operating system on which the original [SplitLab](http://splitting.gm.univ-montp2.fr/)
+StackSplit should run on every operating system on which the original [SplitLab](https://splitting.gm.univ-montp2.fr/)
 package runs. Thus, MATLAB 7.0 or higher, the Mapping Toolbox and for full functionality the Signal Processing
 Toolbox are required. If MATLAB R2014b or higher is running on your system or no license for the
 Mapping Toolbox is available, I recommend to use the [updated SplitLab](https://robporritt.wordpress.com/software/)
@@ -107,7 +107,7 @@ If you make use of StackSplit please acknowledge the following contributing pape
 - **_Roy, C., Winter, A., Ritter, J. R. R., Schweitzer, J. (2017)_**, On the improvement of SKS splitting measurements by the simultaneous inversion of multiple waveforms (SIMW), *Geophysical Journal International*, 208, 1508-1523, https://doi.org/10.1093/gji/ggw470.
 - **_Silver, P. G. & Chan, W. W. (1991)_**, Shear wave splitting and subcontinental mantle deformation. *Journal of Geophysical Research*, 96, 16429-16454, https://doi.org/10.1029/91JB00899.
 - **_Wolfe, C. J. & Silver, P. G. (1998)_**, Seismic anisotropy of oceanic upper mantle: Shear wave splitting methodologies and observations, *Journal of Geophysical Research* 103(B1), 749-771, https://doi.org/10.1029/97JB02023.
-- **_Wüstefeld, A. (2007)_**, Methods and applications of shear wave splitting: The East European Craton. Ph.D. thesis, *Univ. de Montpellier*, France, http://splitting.gm.univ-montp2.fr/.
+- **_Wüstefeld, A. (2007)_**, Methods and applications of shear wave splitting: The East European Craton. Ph.D. thesis, *Univ. de Montpellier*, France, https://splitting.gm.univ-montp2.fr.
 
 
 ## Installation

--- a/02_stacksplit/StackSplit/SS_stacksplit_start.m
+++ b/02_stacksplit/StackSplit/SS_stacksplit_start.m
@@ -71,7 +71,7 @@ function SS_stacksplit_start
 %
 % Wüstefeld, A. (2007), Methods and applications of shear wave splitting:
 %    The East European Craton. PhD thesis, Univ. de Montpellier, France, 
-%    http://splitting.gm.univ-montp2.fr/, last accessed 11 January 2019.
+%    https://splitting.gm.univ-montp2.fr/, last accessed 18 July 2025.
 % 
 % Restivo & Helffrich (1999), Teleseismic shear wave splitting
 %    measurements in noisy environments, GJI 137, 821-830,

--- a/02_stacksplit/changelog.md
+++ b/02_stacksplit/changelog.md
@@ -2,7 +2,7 @@
 
 ## Release dev
 
-> Changes are undependent from the original [StackSplit repo](https://github.com/michaelgrund/stacksplit).
+> Changes are independent from the original [StackSplit repo](https://github.com/michaelgrund/stacksplit).
 > For the changes included in the original StackSplit repo, the related PRs are marked with an asterix (*).
 
 **StackSplit-related**


### PR DESCRIPTION
Finally the SplitLab website is https 🚀.